### PR TITLE
New dependent query API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: use node ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn
+    - run: yarn test

--- a/README.md
+++ b/README.md
@@ -470,11 +470,10 @@ export function setupStore({
 
 Sometimes it's necessary to compose multiple endpoints together.  For example
 we might want to fetch a mailbox and its associated messages.  Every endpoint
-also returns a property on the action creator `.run(props)` which returns a
-redux-saga `call` object that you can yield to.
+also returns a property on the action creator `.run` which returns the saga
+that runs when the action is dispatched.
 
-**WARNING: This API is probably going to change so we don't hardcode `call` as
-the return value.**
+This allows us to `yield` to that saga inside another endpoint.
 
 ```ts
 const fetchMailbox = api.get('/mailboxes');
@@ -482,9 +481,8 @@ const fetchMailbox = api.get('/mailboxes');
 const fetchMessages = api.get<{ id: string }>(
   '/mailboxes/:id/messages',
   function*(ctx, next) {
-    // Under the hood this is just a `yield call(onApi, fetchMailbox(props))`.
     // The return value of a `.run` is the entire `ctx` object.
-    const mailCtx = yield fetchMailbox.run();
+    const mailCtx = yield call(fetchMailbox.run, fetchMailbox());
 
     if (!mailCtx.response.ok) {
       yield next();

--- a/src/create-api.test.ts
+++ b/src/create-api.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import createSagaMiddleware, { SagaIterator } from 'redux-saga';
-import { put } from 'redux-saga/effects';
+import { put, call } from 'redux-saga/effects';
 import { createTable, Action, MapEntity, createReducerMap } from 'robodux';
 
 import { Middleware, Next, createApi } from './create-api';
@@ -294,7 +294,7 @@ test('run() on endpoint action - should run the effect', (t) => {
     '/users2',
     function* (ctx, next): SagaIterator<void> {
       yield next();
-      const curCtx = yield action1.run();
+      const curCtx = yield call(action1.run, action1());
       acc += 'b';
       t.assert(acc === 'ab');
       t.deepEqual(curCtx, {

--- a/src/create-api.ts
+++ b/src/create-api.ts
@@ -48,25 +48,28 @@ export interface SagaApi<Ctx extends ApiCtx> {
   use: (fn: Middleware<Ctx>) => void;
   routes: () => Middleware<Ctx>;
 
-  create(name: string): CreateAction;
-  create<P>(name: string): CreateActionWithPayload<P>;
-  create(name: string, req: { saga?: any }): CreateAction;
-  create<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  create(name: string, fn: Middleware<Ctx> | Middleware<Ctx>[]): CreateAction;
+  create(name: string): CreateAction<Ctx>;
+  create<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  create(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  create<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  create(
+    name: string,
+    fn: Middleware<Ctx> | Middleware<Ctx>[],
+  ): CreateAction<Ctx>;
   create<P>(
     name: string,
     fn: Middleware<Ctx> | Middleware<Ctx>[],
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
   create(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx> | Middleware<Ctx>[],
-  ): CreateAction;
+  ): CreateAction<Ctx>;
   create<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx> | Middleware<Ctx>[],
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 }
 
 export const defaultOnError = (err: Error) => {
@@ -141,7 +144,7 @@ export function createApi<Ctx extends ApiCtx = ApiCtx<any>>({
     }
     sagas[`${createName}`] = curSaga;
     const actionFn = (options?: any) => action({ name: createName, options });
-    actionFn.run = (options?: any) => call(onApi, actionFn(options));
+    actionFn.run = onApi as any;
     actionFn.toString = () => createName;
     return actionFn;
   }

--- a/src/create-query.test.ts
+++ b/src/create-query.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import createSagaMiddleware from 'redux-saga';
-import { put } from 'redux-saga/effects';
+import { put, call } from 'redux-saga/effects';
 import { createReducerMap, MapEntity, createTable } from 'robodux';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { urlParser, queryCtx } from './middleware';
@@ -97,7 +97,7 @@ test('run() on endpoint action - should run the effect', (t) => {
   });
   const action2 = api.get('/users2', function* (ctx, next) {
     yield next();
-    yield action1.run({ id: '1' });
+    yield call(action1.run, action1({ id: '1' }));
     acc += 'b';
     t.assert(acc === 'ab');
   });

--- a/src/create-query.ts
+++ b/src/create-query.ts
@@ -6,122 +6,170 @@ export interface SagaQueryApi<Ctx extends QueryCtx = QueryCtx>
   extends SagaApi<Ctx> {
   request: (r: Ctx['request']) => (ctx: Ctx, next: Next) => SagaIterator<any>;
 
-  get(name: string): CreateAction;
-  get<P>(name: string): CreateActionWithPayload<P>;
-  get(name: string, req: { saga?: any }): CreateAction;
-  get<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  get(name: string, fn: Middleware<Ctx>): CreateAction;
-  get<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  get(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  get(name: string): CreateAction<Ctx>;
+  get<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  get(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  get<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  get(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  get<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  get(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   get<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  post(name: string): CreateAction;
-  post<P>(name: string): CreateActionWithPayload<P>;
-  post(name: string, req: { saga?: any }): CreateAction;
-  post<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  post(name: string, fn: Middleware<Ctx>): CreateAction;
-  post<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  post(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  post(name: string): CreateAction<Ctx>;
+  post<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  post(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  post<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  post(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  post<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  post(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   post<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  put(name: string): CreateAction;
-  put<P>(name: string): CreateActionWithPayload<P>;
-  put(name: string, req: { saga?: any }): CreateAction;
-  put<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  put(name: string, fn: Middleware<Ctx>): CreateAction;
-  put<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  put(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  put(name: string): CreateAction<Ctx>;
+  put<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  put(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  put<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  put(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  put<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  put(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   put<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  patch(name: string): CreateAction;
-  patch<P>(name: string): CreateActionWithPayload<P>;
-  patch(name: string, req: { saga?: any }): CreateAction;
-  patch<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  patch(name: string, fn: Middleware<Ctx>): CreateAction;
-  patch<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  patch(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  patch(name: string): CreateAction<Ctx>;
+  patch<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  patch(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  patch<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  patch(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  patch<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  patch(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   patch<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  delete(name: string): CreateAction;
-  delete<P>(name: string): CreateActionWithPayload<P>;
-  delete(name: string, req: { saga?: any }): CreateAction;
-  delete<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  delete(name: string, fn: Middleware<Ctx>): CreateAction;
-  delete<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  delete(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  delete(name: string): CreateAction<Ctx>;
+  delete<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  delete(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  delete<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  delete(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  delete<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  delete(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   delete<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  options(name: string): CreateAction;
-  options<P>(name: string): CreateActionWithPayload<P>;
-  options(name: string, req: { saga?: any }): CreateAction;
-  options<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  options(name: string, fn: Middleware<Ctx>): CreateAction;
-  options<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  options(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  options(name: string): CreateAction<Ctx>;
+  options<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  options(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  options<P>(
+    name: string,
+    req: { saga?: any },
+  ): CreateActionWithPayload<Ctx, P>;
+  options(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  options<P>(
+    name: string,
+    fn: Middleware<Ctx>,
+  ): CreateActionWithPayload<Ctx, P>;
+  options(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   options<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  head(name: string): CreateAction;
-  head<P>(name: string): CreateActionWithPayload<P>;
-  head(name: string, req: { saga?: any }): CreateAction;
-  head<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  head(name: string, fn: Middleware<Ctx>): CreateAction;
-  head<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  head(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  head(name: string): CreateAction<Ctx>;
+  head<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  head(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  head<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  head(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  head<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  head(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   head<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  connect(name: string): CreateAction;
-  connect<P>(name: string): CreateActionWithPayload<P>;
-  connect(name: string, req: { saga?: any }): CreateAction;
-  connect<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  connect(name: string, fn: Middleware<Ctx>): CreateAction;
-  connect<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  connect(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  connect(name: string): CreateAction<Ctx>;
+  connect<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  connect(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  connect<P>(
+    name: string,
+    req: { saga?: any },
+  ): CreateActionWithPayload<Ctx, P>;
+  connect(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  connect<P>(
+    name: string,
+    fn: Middleware<Ctx>,
+  ): CreateActionWithPayload<Ctx, P>;
+  connect(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   connect<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 
-  trace(name: string): CreateAction;
-  trace<P>(name: string): CreateActionWithPayload<P>;
-  trace(name: string, req: { saga?: any }): CreateAction;
-  trace<P>(name: string, req: { saga?: any }): CreateActionWithPayload<P>;
-  trace(name: string, fn: Middleware<Ctx>): CreateAction;
-  trace<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<P>;
-  trace(name: string, req: { saga?: any }, fn: Middleware<Ctx>): CreateAction;
+  trace(name: string): CreateAction<Ctx>;
+  trace<P>(name: string): CreateActionWithPayload<Ctx, P>;
+  trace(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  trace<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  trace(name: string, fn: Middleware<Ctx>): CreateAction<Ctx>;
+  trace<P>(name: string, fn: Middleware<Ctx>): CreateActionWithPayload<Ctx, P>;
+  trace(
+    name: string,
+    req: { saga?: any },
+    fn: Middleware<Ctx>,
+  ): CreateAction<Ctx>;
   trace<P>(
     name: string,
     req: { saga?: any },
     fn: Middleware<Ctx>,
-  ): CreateActionWithPayload<P>;
+  ): CreateActionWithPayload<Ctx, P>;
 }
 
 export function createQuery<Ctx extends QueryCtx = QueryCtx>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { CallEffect } from 'redux-saga/effects';
+import { SagaIterator } from 'redux-saga';
 
 export interface Action {
   type: string;
@@ -19,13 +19,13 @@ export interface ApiCtx<P = any> {
   action: CreateActionPayload<P>;
 }
 
-export interface CreateAction {
+export interface CreateAction<Ctx> {
   (): ActionWithPayload<CreateActionPayload<{}>>;
-  run: () => CallEffect;
+  run: (p: ActionWithPayload<CreateActionPayload<{}>>) => SagaIterator<Ctx>;
 }
-export interface CreateActionWithPayload<P> {
+export interface CreateActionWithPayload<Ctx, P> {
   (p: P): ActionWithPayload<CreateActionPayload<P>>;
-  run: (p: P) => CallEffect;
+  run: (a: ActionWithPayload<CreateActionPayload<P>>) => SagaIterator<Ctx>;
 }
 
 export interface RequestCtx {


### PR DESCRIPTION
This dependent query API makes it so `.run` simply returns the saga that is activated when an endpoint action is dispatched.  This allows us to use any async flow control that `redux-saga` provides instead of hardcoding `call` in the response.