### PR TITLE
:sparkles: :boom: new feature `prepareStore` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ import { put, call } from 'redux-saga/effects';
 import { createTable, createReducerMap } from 'robodux';
 import {
   createApi,
-  fetchMiddleware,
+  requestParser,
   dispatchActions,
   prepareStore,
   FetchCtx,
@@ -150,7 +150,7 @@ export const { selectTableAsList: selectUsersAsList } = selectors;
 const api = createApi<FetchCtx>();
 api.use(dispatchActions);
 api.use(api.routes());
-api.use(fetchMiddleware());
+api.use(requestParser());
 api.use(function* onFetch(ctx, next) {
   const { url = '', ...options } = ctx.request;
   const resp = yield call(fetch, url, options);
@@ -283,7 +283,7 @@ import { createTable, createReducerMap } from 'robodux';
 import {
   createApi,
   dispatchActions,
-  fetchMiddleware,
+  requestParser,
   // FetchCtx is an interface that's built around using window.fetch
   // You don't have to use it if you don't want to.
   FetchCtx
@@ -311,14 +311,14 @@ api.use(dispatchActions);
 api.use(api.routes());
 
 // This middleware is composed of other middleware: queryCtx, urlParser, and
-// loadingTracker.
+// loadingMonitor.
 // [queryCtx] sets up the ctx object with `ctx.request` and `ctx.response`
 //  required for `createApi` to function properly.
 // [urlParser] is a middleware that will take the name of `api.create(name)` and
 //  replace it with the values passed into the action.
-// [loadingTracker] is a middleware that will handle loading state for all
+// [loadingMonitor] is a middleware that will handle loading state for all
 //  endpoints.
-api.use(fetchMiddleware());
+api.use(requestParser());
 
 // this is where you defined your core fetching logic
 api.use(function* onFetch(ctx, next) {
@@ -451,7 +451,7 @@ upstream library.
 import { 
   createApi,
   dispatchActions,
-  fetchMiddleware,
+  requestParser,
   timer,
   prepareStore,
 } from 'saga-query';
@@ -459,7 +459,7 @@ import {
 const api = createApi();
 api.use(dispatchActions);
 api.use(api.routes());
-api.use(fetchMiddleware());
+api.use(requestParser());
 
 // made up api fetch
 api.use(apiFetch);
@@ -690,8 +690,9 @@ store.dispatch(action());
 
 ### Loading state
 
-When using `prepareStore` in conjunction with `dispatchActions` and
-`fetchMiddleware` (or `trackLoading`) the loading state will automatically be
+When using `prepareStore` in conjunction with `dispatchActions`,
+`loadingMonitor`, and
+`requestParser` the loading state will automatically be
 added to all of your endpoints.  We also export `QueryState` which is the
 interface that contains all the state types that `saga-query` provides.
 
@@ -1077,7 +1078,7 @@ import {
   prepareStore, 
   createApi, 
   dispatchAction, 
-  fetchMiddleware,
+  requestParser,
 } from 'saga-query';
 import { createSlice } from 'redux-toolkit';
 
@@ -1096,7 +1097,7 @@ const users = createSlice({
 const api = createApi();
 api.use(dispatchActions);
 api.use(api.routes());
-api.use(fetchMiddleware);
+api.use(requestParser());
 // made up window.fetch logic
 api.use(apiFetch);
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ import { createTable, createReducerMap } from 'robodux';
 import {
   createApi,
   requestParser,
+  loadingMonitor,
   dispatchActions,
   prepareStore,
   FetchCtx,
@@ -149,6 +150,7 @@ export const { selectTableAsList: selectUsersAsList } = selectors;
 
 const api = createApi<FetchCtx>();
 api.use(dispatchActions);
+api.use(loadingMonitor());
 api.use(api.routes());
 api.use(requestParser());
 api.use(function* onFetch(ctx, next) {
@@ -301,8 +303,14 @@ const api = createApi<FetchCtx>();
 
 // This middleware leverages `redux-batched-actions` to dispatch all the
 // actions stored within `ctx.actions` which get added by other middleware
-// during the lifecycle of the request.
+// during the lifecycle of the request.  This middleware should almost always
+// preceed `api.routes()`
 api.use(dispatchActions);
+
+// This middleware will monitor the lifecycle of a request and attach the
+// appropriate loading states to the loader associated with the endpoint.
+// This middleware should almost always preceed `api.routes()`
+api.use(loadingMonitor());
 
 // This is where all the endpoints (e.g. `.get()`, `.put()`, etc.) you created
 // get added to the middleware stack.  It is recommended to put this as close to
@@ -311,13 +319,13 @@ api.use(dispatchActions);
 api.use(api.routes());
 
 // This middleware is composed of other middleware: queryCtx, urlParser, and
-// loadingMonitor.
+// simpleCache
 // [queryCtx] sets up the ctx object with `ctx.request` and `ctx.response`
 //  required for `createApi` to function properly.
 // [urlParser] is a middleware that will take the name of `api.create(name)` and
 //  replace it with the values passed into the action.
-// [loadingMonitor] is a middleware that will handle loading state for all
-//  endpoints.
+// [simpleCache] is a middleware that will automatically store the response of
+//  endpoints if the endpoint has request.simpleCache = true
 api.use(requestParser());
 
 // this is where you defined your core fetching logic
@@ -452,12 +460,14 @@ import {
   createApi,
   dispatchActions,
   requestParser,
+  loadingMonitor,
   timer,
   prepareStore,
 } from 'saga-query';
 
 const api = createApi();
 api.use(dispatchActions);
+api.use(loadingMonitor());
 api.use(api.routes());
 api.use(requestParser());
 
@@ -1079,6 +1089,7 @@ import {
   createApi, 
   dispatchAction, 
   requestParser,
+  loadingMonitor,
 } from 'saga-query';
 import { createSlice } from 'redux-toolkit';
 
@@ -1096,6 +1107,7 @@ const users = createSlice({
 
 const api = createApi();
 api.use(dispatchActions);
+api.use(loadingMonitor());
 api.use(api.routes());
 api.use(requestParser());
 // made up window.fetch logic

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![ci](https://github.com/neurosnap/saga-query/actions/workflows/test.yml/badge.svg)](https://github.com/neurosnap/saga-query/actions/workflows/test.yml)
 
-Data fetching and caching using a middleware system.  
-Use our saga middleware system to quickly build data loading within your 
-redux application and reduce boilderplate.
+Data fetching and caching using a robust middleware system.
+Quickly build data loading within your redux application and reduce boilderplate.
 
 **This library is undergoing active development. Consider this in a beta
 state.**
@@ -32,12 +31,11 @@ state.**
 - Write middleware to handle fetching, synchronizing, and caching API requests
   on the front-end
 - A familiar middleware system that node.js developers are familiar with
-  (e.g. express, koa)
-- Handle any async flow control use-case
-- Full control over the data fetching and caching layers in your application
-- Fine tune selectors for your specific needs
+  (e.g. koa)
 - Simple recipes to handle complex use-cases like cancellation, polling,
   optimistic updates, loading states, undo, react
+- Full control over the data fetching and caching layers in your application
+- Fine tune selectors for your specific needs
 
 ## Why?
 
@@ -47,14 +45,13 @@ Libraries like [react-query](https://react-query.tanstack.com/),
 easier than ever to fetch and cache data from an API server.  All of them
 have their unique attributes and I encourage everyone to check them out.
 
-I find that the async flow control of `redux-saga` is one of the most robust
-and powerful declaractive side-effect systems I have used.  Treating
+There's no better async flow control system than `redux-saga`.  Treating
 side-effects as data makes testing dead simple and provides a powerful effect
-handling system to accomodate any use-case.  Features like polling, data
-loading states, cancellation, racing, parallelization, optimistic updates,
-and undo are at your disposal when using `redux-saga`.  Other
-libraries and paradigms can also accomplish the same tasks, but I think nothing
-rivals the readability and maintainability of redux/redux-saga.
+handling system to accomodate any use-case.  Features like polling, data loading
+states, cancellation, racing, parallelization, optimistic updates, and undo are
+at your disposal when using `redux-saga`.  Other libraries and paradigms can
+also accomplish the same tasks, but I think nothing rivals the readability and
+maintainability of redux/redux-saga.
 
 All three libraries above are reinventing async flow control and hiding them
 from the end-developer.  For the happy path, this works beautifully.  Why learn
@@ -178,7 +175,7 @@ export const fetchUsers = api.get(
 
 const reducers = createReducerMap(users);
 const prepared = prepareStore({
-  reducers, 
+  reducers,
   sagas: { api: api.saga() },
 });
 const store = createStore(
@@ -389,7 +386,7 @@ const reducers = createReducerMap(users);
 //   - Setup redux-batched-actions
 //   - Setup a couple of reducers that saga-query will use: loaders and data
 const prepared = prepareStore({
-  reducers, 
+  reducers,
   sagas: { api: api.saga() }
 });
 const store = createStore(
@@ -446,9 +443,9 @@ each endpoint.
 
 The following code will mimick what a library like `react-query` is doing
 behind-the-scenes.  I want to make it clear that `react-query` is doing a lot
-more than this so I don't want to understate its usefuless.  However, you can 
+more than this so I don't want to understate its usefuless.  However, you can
 see that not only can we get a core chunk of the functionality `react-query`
-provides with a little over 100 lines of code but we also have full control 
+provides with a little over 100 lines of code but we also have full control
 over fetching, querying, and caching data with the ability to customize it
 using middleware.  This provides the end-developer with the tools to customize
 their experience without submitting PRs to add configuration options to an
@@ -456,7 +453,7 @@ upstream library.
 
 ```ts
 // api.ts
-import { 
+import {
   createApi,
   dispatchActions,
   requestParser,
@@ -477,14 +474,14 @@ api.use(apiFetch);
 // this will only activate the endpoint at most once every 5 minutes.
 const cacheTimer = timer(5 * 60 * 1000);
 export const fetchUsers = api.get(
-  '/users', 
-  { saga: cacheTimer }, 
-  // set `save=true` to have quickSave middleware cache response data 
+  '/users',
+  { saga: cacheTimer },
+  // set `save=true` to have quickSave middleware cache response data
   // automatically
-  api.request({ save: true }), 
+  api.request({ save: true }),
 );
 
-const prepared = prepareStore({ 
+const prepared = prepareStore({
   sagas: { api: api.saga() },
 });
 const store = createStore(
@@ -994,7 +991,7 @@ The middleware accepts three properties:
 
 - `doItType` (default: `${doIt}`) => action type
 - `undoType` (default: `${undo}`) => action type
-- `timeout` (default: 30 * 1000) => time in milliseconds before the endpoint 
+- `timeout` (default: 30 * 1000) => time in milliseconds before the endpoint
   get cancelled automatically
 
 ```ts
@@ -1084,10 +1081,10 @@ response data.
 ```ts
 import { createStore } from 'redux';
 import { createReducerMap } from 'robodux';
-import { 
-  prepareStore, 
-  createApi, 
-  dispatchAction, 
+import {
+  prepareStore,
+  createApi,
+  dispatchAction,
   requestParser,
   loadingMonitor,
 } from 'saga-query';

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci](https://github.com/neurosnap/saga-query/actions/workflows/test.yml/badge.svg)](https://github.com/neurosnap/saga-query/actions/workflows/test.yml)
 
-Data fetching and caching using a middleware system for the browser.  
+Data fetching and caching using a middleware system.  
 Use our saga middleware system to quickly build data loading within your 
 redux application and reduce boilderplate.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "redux": "^4.1.0",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
-    "robodux": "^11.0.1",
+    "robodux": "^11.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
   },
@@ -32,6 +32,7 @@
     "redux-saga": "^1.1.3"
   },
   "dependencies": {
+    "redux-batched-actions": "^0.5.0",
     "redux-saga-creator": "^2.0.1"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "redux": "^4.1.0",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
-    "robodux": "^11.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
   },
@@ -33,7 +32,8 @@
   },
   "dependencies": {
     "redux-batched-actions": "^0.5.0",
-    "redux-saga-creator": "^2.0.1"
+    "redux-saga-creator": "^2.0.1",
+    "robodux": "^11.0.2"
   },
   "ava": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saga-query",
   "version": "0.0.0",
-  "description": "Data synchronization using redux-saga",
+  "description": "Data fetching and caching using a middleware system",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": "https://github.com/neurosnap/saga-query.git",

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import createSagaMiddleware, { SagaIterator } from 'redux-saga';
-import { put, call } from 'redux-saga/effects';
+import { takeEvery, put, call } from 'redux-saga/effects';
 import {
   createAction,
   createReducerMap,
@@ -13,6 +13,7 @@ import sagaCreator from 'redux-saga-creator';
 import { urlParser, queryCtx } from './middleware';
 import { FetchCtx } from './fetch';
 import { createApi } from './api';
+import { setupStore } from './util';
 
 interface User {
   id: string;
@@ -22,17 +23,6 @@ interface User {
 
 const mockUser: User = { id: '1', name: 'test', email: 'test@test.com' };
 const mockUser2: User = { id: '2', name: 'two', email: 'two@test.com' };
-
-function setupStore(
-  saga: any,
-  reducers: any = { users: (state: any = {}) => state },
-) {
-  const sagaMiddleware = createSagaMiddleware();
-  const reducer = combineReducers(reducers);
-  const store: any = createStore(reducer, applyMiddleware(sagaMiddleware));
-  sagaMiddleware.run(saga);
-  return store;
-}
 
 test('createApi - POST', (t) => {
   t.plan(1);
@@ -138,6 +128,10 @@ test('run() from a normal saga', (t) => {
     t.assert(acc === 'ab');
   }
 
-  const store = setupStore(sagaCreator({ api: api.saga(), action: onAction }));
+  function* watchAction() {
+    yield takeEvery(`${action2}`, onAction);
+  }
+
+  const store = setupStore({ api: api.saga(), watchAction });
   store.dispatch(action2());
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -202,7 +202,7 @@ export function createApi<Ctx extends ApiCtx = ApiCtx>(
     patch: (name: string, ...args: any[]) =>
       (api.create as any)(`${name} [PATCH]`, ...args),
     delete: (name: string, ...args: any[]) =>
-      (api.create as any)(`${name} [PATCH]`, ...args),
+      (api.create as any)(`${name} [DELETE]`, ...args),
     options: (name: string, ...args: any[]) =>
       (api.create as any)(`${name} [OPTIONS]`, ...args),
     head: (name: string, ...args: any[]) =>

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,10 +1,11 @@
 import { call } from 'redux-saga/effects';
 
-import { ApiCtx, CreateActionPayload, Next } from './types';
-import { queryCtx, urlParser } from './middleware';
+import { ApiCtx, CreateActionPayload, Next, RequestData } from './types';
+import { queryCtx, urlParser, LoadingCtx } from './middleware';
 
 export interface FetchApiOpts extends RequestInit {
   url: string;
+  data: RequestData;
 }
 
 export interface ApiFetchSuccess<Data = any> {
@@ -23,7 +24,9 @@ export type ApiFetchResponse<Data = any, E = any> =
   | ApiFetchSuccess<Data>
   | ApiFetchError<E>;
 
-export interface FetchCtx<D = any, E = any, P = any> extends ApiCtx {
+export interface FetchCtx<D = any, E = any, P = any>
+  extends ApiCtx,
+    LoadingCtx {
   payload: P;
   request: Partial<FetchApiOpts>;
   response: ApiFetchResponse<D, E>;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,7 +1,8 @@
 import { call } from 'redux-saga/effects';
 
 import { ApiCtx, CreateActionPayload, Next, RequestData } from './types';
-import { queryCtx, urlParser, LoadingCtx } from './middleware';
+import { queryCtx, urlParser, LoadingCtx, loadingTracker } from './middleware';
+import { compose } from './pipe';
 
 export interface FetchApiOpts extends RequestInit {
   url: string;
@@ -30,4 +31,10 @@ export interface FetchCtx<D = any, E = any, P = any>
   payload: P;
   request: Partial<FetchApiOpts>;
   response: ApiFetchResponse<D, E>;
+}
+
+export function fetchMiddleware<Ctx extends FetchCtx = FetchCtx>(
+  err: (ctx: Ctx) => any,
+) {
+  return compose<Ctx>([queryCtx, urlParser, loadingTracker(err)]);
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,4 @@
-import { ApiCtx, RequestData } from './types';
-import { LoadingCtx } from './middleware';
+import { ApiCtx, RequestData, LoadingCtx } from './types';
 
 export interface FetchApiOpts extends RequestInit {
   url: string;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,7 +1,13 @@
 import { call } from 'redux-saga/effects';
 
 import { ApiCtx, CreateActionPayload, Next, RequestData } from './types';
-import { queryCtx, urlParser, LoadingCtx, loadingTracker } from './middleware';
+import {
+  queryCtx,
+  urlParser,
+  LoadingCtx,
+  loadingTracker,
+  quickSave,
+} from './middleware';
 import { compose } from './pipe';
 
 export interface FetchApiOpts extends RequestInit {
@@ -36,5 +42,5 @@ export interface FetchCtx<D = any, E = any, P = any>
 export function fetchMiddleware<Ctx extends FetchCtx = FetchCtx>(
   err: (ctx: Ctx) => any,
 ) {
-  return compose<Ctx>([queryCtx, urlParser, loadingTracker(err)]);
+  return compose<Ctx>([queryCtx, urlParser, loadingTracker(err), quickSave]);
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,18 +1,10 @@
-import { call } from 'redux-saga/effects';
-
-import { ApiCtx, CreateActionPayload, Next, RequestData } from './types';
-import {
-  queryCtx,
-  urlParser,
-  LoadingCtx,
-  loadingTracker,
-  quickSave,
-} from './middleware';
-import { compose } from './pipe';
+import { ApiCtx, RequestData } from './types';
+import { LoadingCtx } from './middleware';
 
 export interface FetchApiOpts extends RequestInit {
   url: string;
   data: RequestData;
+  simpleCache: boolean;
 }
 
 export interface ApiFetchSuccess<Data = any> {
@@ -37,10 +29,4 @@ export interface FetchCtx<D = any, E = any, P = any>
   payload: P;
   request: Partial<FetchApiOpts>;
   response: ApiFetchResponse<D, E>;
-}
-
-export function fetchMiddleware<Ctx extends FetchCtx = FetchCtx>(
-  err: (ctx: Ctx) => any,
-) {
-  return compose<Ctx>([queryCtx, urlParser, loadingTracker(err), quickSave]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
+export { BATCH, batchActions } from 'redux-batched-actions';
 export * from './pipe';
 export * from './api';
 export * from './types';
 export * from './fetch';
 export * from './middleware';
 export * from './constants';
+export * from './store';
+export * from './slice';

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -12,11 +12,9 @@ import { Next } from './types';
 import { createApi } from './api';
 import {
   urlParser,
-  loadingMonitor,
   queryCtx,
-  LoadingCtx,
-  dispatchActions,
   requestParser,
+  requestMonitor,
 } from './middleware';
 import { FetchCtx } from './fetch';
 import { setupStore } from './util';
@@ -106,11 +104,9 @@ test('middleware - with loader', (t) => {
   const users = createTable<User>({ name: 'users' });
 
   const api = createApi<FetchCtx>();
-  api.use(dispatchActions);
-  api.use(loadingMonitor());
+  api.use(requestMonitor());
   api.use(api.routes());
-  api.use(queryCtx);
-  api.use(urlParser);
+  api.use(requestParser());
   api.use(function* fetchApi(ctx, next) {
     ctx.response = {
       status: 200,
@@ -200,8 +196,7 @@ test('overriding default loader behavior', (t) => {
   const users = createTable<User>({ name: 'users' });
 
   const api = createApi<FetchCtx>();
-  api.use(dispatchActions);
-  api.use(loadingMonitor());
+  api.use(requestMonitor());
   api.use(api.routes());
   api.use(requestParser());
 
@@ -254,8 +249,7 @@ test('overriding default loader behavior', (t) => {
 
 test('quickSave', (t) => {
   const api = createApi<FetchCtx>();
-  api.use(dispatchActions);
-  api.use(loadingMonitor());
+  api.use(requestMonitor());
   api.use(api.routes());
   api.use(requestParser());
   api.use(function* fetchApi(ctx, next) {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -7,12 +7,19 @@ import {
   createTable,
   createLoaderTable,
 } from 'robodux';
-import { createStore, combineReducers, applyMiddleware } from 'redux';
 
 import { Next } from './types';
 import { createApi } from './api';
-import { urlParser, loadingTracker, queryCtx } from './middleware';
+import {
+  urlParser,
+  loadingTracker,
+  queryCtx,
+  LoadingCtx,
+  dispatchActions,
+} from './middleware';
 import { FetchCtx } from './fetch';
+import { setupStore } from './util';
+import { LOADERS_NAME, createQueryState } from './slice';
 
 interface User {
   id: string;
@@ -22,14 +29,6 @@ interface User {
 
 const mockUser: User = { id: '1', name: 'test', email: 'test@test.com' };
 const mockUser2: User = { id: '2', name: 'two', email: 'two@test.com' };
-
-function setupStore(saga: any, reducers: any) {
-  const sagaMiddleware = createSagaMiddleware();
-  const reducer = combineReducers(reducers);
-  const store: any = createStore(reducer, applyMiddleware(sagaMiddleware));
-  sagaMiddleware.run(saga);
-  return store;
-}
 
 function* latest(action: string, saga: any, ...args: any[]) {
   yield takeLatest(`${action}`, saga, ...args);
@@ -92,27 +91,22 @@ test('middleware - basic', (t) => {
   const store = setupStore(query.saga(), reducers);
   store.dispatch(fetchUsers());
   t.deepEqual(store.getState(), {
+    ...createQueryState(),
     users: { [mockUser.id]: mockUser },
   });
   store.dispatch(fetchUser({ id: '2' }));
   t.deepEqual(store.getState(), {
+    ...createQueryState(),
     users: { [mockUser.id]: mockUser, [mockUser2.id]: mockUser2 },
   });
 });
 
 test('middleware - with loader', (t) => {
   const users = createTable<User>({ name: 'users' });
-  const loaders = createLoaderTable({ name: 'loaders' });
 
   const api = createApi<FetchCtx>();
-  api.use(function* (ctx, next) {
-    yield next();
-    for (let i = 0; i < ctx.actions.length; i += 1) {
-      const action = ctx.actions[i];
-      yield put(action);
-    }
-  });
-  api.use(loadingTracker(loaders));
+  api.use(dispatchActions);
+  api.use(loadingTracker());
   api.use(api.routes());
   api.use(queryCtx);
   api.use(urlParser);
@@ -142,13 +136,13 @@ test('middleware - with loader', (t) => {
     },
   );
 
-  const reducers = createReducerMap(loaders, users);
+  const reducers = createReducerMap(users);
   const store = setupStore(api.saga(), reducers);
 
   store.dispatch(fetchUsers());
   t.like(store.getState(), {
     [users.name]: { [mockUser.id]: mockUser },
-    [loaders.name]: {
+    [LOADERS_NAME]: {
       '/users': {
         status: 'success',
       },
@@ -199,4 +193,60 @@ test('middleware - with POST', (t) => {
   const reducers = createReducerMap(cache);
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUser({ email: mockUser.email }));
+});
+
+test('overriding default loader behavior', (t) => {
+  const users = createTable<User>({ name: 'users' });
+
+  const api = createApi<FetchCtx>();
+  api.use(dispatchActions);
+  api.use(loadingTracker());
+  api.use(api.routes());
+  api.use(queryCtx);
+  api.use(urlParser);
+  api.use(function* fetchApi(ctx, next) {
+    ctx.response = {
+      status: 200,
+      ok: true,
+      data: {
+        users: [mockUser],
+      },
+    };
+    yield next();
+  });
+
+  const fetchUsers = api.create(
+    `/users`,
+    function* processUsers(ctx: FetchCtx<{ users: User[] }>, next) {
+      const id = ctx.name;
+      yield next();
+      if (!ctx.response.ok) {
+        ctx.loader.error = { id, message: 'boo' };
+        return;
+      }
+      const { data } = ctx.response;
+      const curUsers = data.users.reduce<MapEntity<User>>((acc, u) => {
+        acc[u.id] = u;
+        return acc;
+      }, {});
+
+      ctx.loader.success = { id, message: 'yes', meta: { wow: true } };
+      ctx.actions.push(users.actions.add(curUsers));
+    },
+  );
+
+  const reducers = createReducerMap(users);
+  const store = setupStore(api.saga(), reducers);
+
+  store.dispatch(fetchUsers());
+  t.like(store.getState(), {
+    [users.name]: { [mockUser.id]: mockUser },
+    [LOADERS_NAME]: {
+      '/users': {
+        status: 'success',
+        message: 'yes',
+        meta: { wow: true },
+      },
+    },
+  });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,6 +70,7 @@ export function* urlParser<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
     ctx.request.url = url;
   }
 
+  // TODO: should this be a separate middleware?
   if (!ctx.request.body && ctx.request.data) {
     ctx.request.body = {
       body: JSON.stringify(ctx.request.data),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,7 +19,12 @@ import {
   Next,
 } from './types';
 import { isObject, createAction } from './util';
-import { setLoaderStart, setLoaderError, setLoaderSuccess } from './slice';
+import {
+  setLoaderStart,
+  setLoaderError,
+  setLoaderSuccess,
+  addData,
+} from './slice';
 
 export function* queryCtx<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
   if (!ctx.request) ctx.request = { url: '', method: 'GET' };
@@ -239,4 +244,14 @@ export function* optimistic<
   if (!ctx.response.ok) {
     yield put(revert);
   }
+}
+
+export function* quickSave<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
+  yield next();
+  if (!ctx.request.save) return;
+  const { ok, data } = ctx.response;
+  if (!ok) return;
+
+  const key = JSON.stringify(ctx.action);
+  ctx.actions.push(addData({ [key]: data }));
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,6 +17,7 @@ import {
   CreateActionPayload,
   ApiCtx,
   Next,
+  LoaderCtxPayload,
 } from './types';
 import { isObject, createAction } from './util';
 import {
@@ -98,23 +99,7 @@ export function* dispatchActions<Ctx extends ApiCtx = ApiCtx>(
   yield put(batchActions(ctx.actions));
 }
 
-interface LoaderPayload {
-  id: string;
-  message?: string;
-  meta?: { [key: string]: any };
-}
-
-interface LoaderCtxPayload {
-  loading: LoaderPayload;
-  success: LoaderPayload;
-  error: LoaderPayload;
-}
-
-export interface LoadingCtx<P = any, R = any> extends ApiCtx<P, R> {
-  loader: LoaderCtxPayload;
-}
-
-export function loadingMonitor<Ctx extends LoadingCtx = LoadingCtx>(
+export function loadingMonitor<Ctx extends ApiCtx = ApiCtx>(
   errorFn: (ctx: Ctx) => string = (ctx) => ctx.response.data.message,
 ) {
   return function* trackLoading(ctx: Ctx, next: Next) {
@@ -261,4 +246,8 @@ export function* simpleCache<Ctx extends ApiCtx = ApiCtx>(
 
 export function requestParser<Ctx extends ApiCtx = ApiCtx>() {
   return compose<Ctx>([queryCtx, urlParser, simpleCache]);
+}
+
+export function requestMonitor<Ctx extends ApiCtx = ApiCtx>() {
+  return compose<Ctx>([dispatchActions, loadingMonitor()]);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -114,7 +114,7 @@ export interface LoadingCtx<P = any, R = any> extends ApiCtx<P, R> {
   loader: LoaderCtxPayload;
 }
 
-export function loadingTracker<Ctx extends LoadingCtx = LoadingCtx>(
+export function loadingMonitor<Ctx extends LoadingCtx = LoadingCtx>(
   errorFn: (ctx: Ctx) => string = (ctx) => ctx.response.data.message,
 ) {
   return function* trackLoading(ctx: Ctx, next: Next) {
@@ -246,12 +246,16 @@ export function* optimistic<
   }
 }
 
-export function* quickSave<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
+export function* quickCache<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
   yield next();
-  if (!ctx.request.save) return;
+  if (!ctx.request.simpleCache) return;
   const { ok, data } = ctx.response;
   if (!ok) return;
 
   const key = JSON.stringify(ctx.action);
   ctx.actions.push(addData({ [key]: data }));
+}
+
+export function requestParser<Ctx extends ApiCtx = ApiCtx>() {
+  return compose<Ctx>([queryCtx, urlParser, quickCache]);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -246,7 +246,10 @@ export function* optimistic<
   }
 }
 
-export function* quickCache<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
+export function* simpleCache<Ctx extends ApiCtx = ApiCtx>(
+  ctx: Ctx,
+  next: Next,
+) {
   yield next();
   if (!ctx.request.simpleCache) return;
   const { ok, data } = ctx.response;
@@ -257,5 +260,5 @@ export function* quickCache<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
 }
 
 export function requestParser<Ctx extends ApiCtx = ApiCtx>() {
-  return compose<Ctx>([queryCtx, urlParser, quickCache]);
+  return compose<Ctx>([queryCtx, urlParser, simpleCache]);
 }

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -6,6 +6,8 @@ import { createTable, Action, MapEntity, createReducerMap } from 'robodux';
 
 import { createPipe } from './pipe';
 import { CreateActionPayload, PipeCtx, Middleware, Next } from './types';
+import { setupStore as prepStore } from './util';
+import { createQueryState } from './slice';
 
 interface RoboCtx<D = any, P = any> extends PipeCtx<P> {
   url: string;
@@ -135,10 +137,7 @@ function* saveToRedux(ctx: RoboCtx, next: Next) {
 }
 
 function setupStore(saga: any) {
-  const sagaMiddleware = createSagaMiddleware();
-  const reducer = combineReducers(reducers as any);
-  const store: any = createStore(reducer, applyMiddleware(sagaMiddleware));
-  sagaMiddleware.run(saga);
+  const store = prepStore(saga, reducers);
   return store;
 }
 
@@ -156,6 +155,7 @@ test('createPipe: when create a query fetch pipeline - execute all middleware an
   const store = setupStore(api.saga());
   store.dispatch(fetchUsers());
   t.deepEqual(store.getState(), {
+    ...createQueryState(),
     [users.name]: { [mockUser.id]: deserializeUser(mockUser) },
     [tickets.name]: {},
   });
@@ -191,6 +191,7 @@ test('createPipe: when providing a generator the to api.create function - should
   const store = setupStore(api.saga());
   store.dispatch(fetchTickets());
   t.deepEqual(store.getState(), {
+    ...createQueryState(),
     [users.name]: { [mockUser.id]: deserializeUser(mockUser) },
     [tickets.name]: { [mockTicket.id]: deserializeTicket(mockTicket) },
   });

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -1,0 +1,38 @@
+import { Reducer } from 'redux';
+import {
+  createTable,
+  createLoaderTable,
+  createReducerMap,
+  LoadingItemState,
+} from 'robodux';
+
+export interface QueryState {
+  '@@saga-query/loaders': { [key: string]: LoadingItemState };
+  '@@saga-query/data': { [key: string]: any };
+}
+
+export const LOADERS_NAME = `@@saga-query/loaders`;
+export const loaders = createLoaderTable({ name: LOADERS_NAME });
+export const {
+  loading: setLoaderStart,
+  error: setLoaderError,
+  success: setLoaderSuccess,
+  resetById: resetLoaderById,
+} = loaders.actions;
+export const { selectTable: selectLoaders, selectById: selectLoaderById } =
+  loaders.getSelectors((state: any) => state[LOADERS_NAME] || {});
+
+const DATA_NAME = `@@saga-query/data`;
+const data = createTable<any>({ name: DATA_NAME });
+export const { selectTable: selectData, selectById: selectDataById } =
+  data.getSelectors((s: any) => s[DATA_NAME] || {});
+
+export const reducers = createReducerMap(loaders, data);
+
+export const createQueryState = (s: Partial<QueryState> = {}): QueryState => {
+  return {
+    [LOADERS_NAME]: {},
+    [DATA_NAME]: {},
+    ...s,
+  };
+};

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -23,9 +23,10 @@ export const { selectTable: selectLoaders, selectById: selectLoaderById } =
   loaders.getSelectors((state: any) => state[LOADERS_NAME] || {});
 
 const DATA_NAME = `@@saga-query/data`;
-const data = createTable<any>({ name: DATA_NAME });
+export const data = createTable<any>({ name: DATA_NAME });
 export const { selectTable: selectData, selectById: selectDataById } =
   data.getSelectors((s: any) => s[DATA_NAME] || {});
+export const { add: addData } = data.actions;
 
 export const reducers = createReducerMap(loaders, data);
 

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -22,7 +22,7 @@ export const {
 export const { selectTable: selectLoaders, selectById: selectLoaderById } =
   loaders.getSelectors((state: any) => state[LOADERS_NAME] || {});
 
-const DATA_NAME = `@@saga-query/data`;
+export const DATA_NAME = `@@saga-query/data`;
 export const data = createTable<any>({ name: DATA_NAME });
 export const { selectTable: selectData, selectById: selectDataById } =
   data.getSelectors((s: any) => s[DATA_NAME] || {});

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,71 @@
+import {
+  createStore as createReduxStore,
+  applyMiddleware,
+  Reducer,
+  Middleware,
+  combineReducers,
+} from 'redux';
+import sagaCreator from 'redux-saga-creator';
+import createSagaMiddleware, {
+  stdChannel,
+  Saga,
+  Task,
+  SagaIterator,
+} from 'redux-saga';
+import { enableBatching, BATCH } from 'redux-batched-actions';
+import { ActionWithPayload } from './types';
+import { reducers as sagaQueryReducers, QueryState } from './slice';
+
+export interface PrepareStore<
+  S extends { [key: string]: any } = { [key: string]: any },
+> {
+  reducer: Reducer<S & QueryState>;
+  middleware: Middleware<any, S, any>[];
+  run: (...args: any[]) => Task;
+}
+
+interface Props<S extends { [key: string]: any } = { [key: string]: any }> {
+  reducers: { [key in keyof S]: Reducer<S[key]> };
+  sagas: { [key: string]: Saga<any> };
+  onError?: (err: Error) => void;
+}
+
+/**
+ * prepareStore will setup redux-batched-actions to work with redux-saga.
+ * It will also add some reducers to your redux store for decoupled loaders
+ * and a simple data cache.
+ *
+ * const { middleware, reducer, run } = prepareStore({
+ *  reducers: { users: (state, action) => state },
+ *  sagas: { api: api.saga() },
+ *  onError: (err) => console.error(err),
+ * });
+ * const store = createStore(reducer, {}, applyMiddleware(...middleware));
+ * // you must call `.run(...args: any[])` in order for the sagas to bootup.
+ * run();
+ */
+export function prepareStore<
+  S extends { [key: string]: any } = { [key: string]: any },
+>({ reducers, sagas, onError = console.error }: Props<S>): PrepareStore<S> {
+  const middleware: Middleware<any, S, any>[] = [];
+
+  const channel = stdChannel();
+  const rawPut = channel.put;
+  channel.put = (action: ActionWithPayload<any>) => {
+    if (action.type === BATCH) {
+      action.payload.forEach(rawPut);
+      return;
+    }
+    rawPut(action);
+  };
+
+  const sagaMiddleware = createSagaMiddleware({ channel } as any);
+  middleware.push(sagaMiddleware);
+
+  const reducer = combineReducers({ ...sagaQueryReducers, ...reducers });
+  const rootReducer: any = enableBatching(reducer);
+  const rootSaga = sagaCreator(sagas, onError);
+  const run = (...args: any[]) => sagaMiddleware.run(rootSaga, ...args);
+
+  return { middleware, reducer: rootReducer, run };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,7 +46,11 @@ interface Props<S extends { [key: string]: any } = { [key: string]: any }> {
  */
 export function prepareStore<
   S extends { [key: string]: any } = { [key: string]: any },
->({ reducers, sagas, onError = console.error }: Props<S>): PrepareStore<S> {
+>({
+  reducers = {} as any,
+  sagas,
+  onError = console.error,
+}: Props<S>): PrepareStore<S> {
   const middleware: Middleware<any, S, any>[] = [];
 
   const channel = stdChannel();

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,22 @@ export interface CreateActionWithPayload<Ctx, P> {
   run: (a: ActionWithPayload<CreateActionPayload<P>>) => SagaIterator<Ctx>;
 }
 
+interface LoaderPayload {
+  id: string;
+  message?: string;
+  meta?: { [key: string]: any };
+}
+
+export interface LoaderCtxPayload {
+  loading: LoaderPayload;
+  success: LoaderPayload;
+  error: LoaderPayload;
+}
+
+export interface LoadingCtx {
+  loader: LoaderCtxPayload;
+}
+
 export interface RequestData {
   [key: string]: any;
 }
@@ -43,7 +59,7 @@ export interface RequestCtx {
   simpleCache: boolean;
 }
 
-export interface ApiCtx<P = any, R = any> extends PipeCtx<P> {
+export interface ApiCtx<P = any, R = any> extends PipeCtx<P>, LoadingCtx {
   request: Partial<RequestCtx>;
   response: R;
   actions: Action[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,9 +31,15 @@ export interface CreateActionWithPayload<Ctx, P> {
   run: (a: ActionWithPayload<CreateActionPayload<P>>) => SagaIterator<Ctx>;
 }
 
+export interface RequestData {
+  [key: string]: any;
+}
+
 export interface RequestCtx {
   url: string;
   method: string;
+  body: any;
+  data: RequestData;
 }
 
 export interface ApiCtx<P = any, R = any> extends PipeCtx<P> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface RequestCtx {
   method: string;
   body: any;
   data: RequestData;
-  save: boolean;
+  simpleCache: boolean;
 }
 
 export interface ApiCtx<P = any, R = any> extends PipeCtx<P> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface RequestCtx {
   method: string;
   body: any;
   data: RequestData;
+  save: boolean;
 }
 
 export interface ApiCtx<P = any, R = any> extends PipeCtx<P> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,6 @@
+import { Reducer, combineReducers, createStore, applyMiddleware } from 'redux';
+import { prepareStore } from './store';
+
 import { API_ACTION_PREFIX } from './constants';
 export const isFn = (fn?: any) => fn && typeof fn === 'function';
 export const isObject = (obj?: any) => typeof obj === 'object' && obj !== null;
@@ -8,3 +11,20 @@ export const createAction = (curType: string) => {
   action.toString = () => type;
   return action;
 };
+
+export function setupStore<S = any>(
+  saga: any,
+  reducers: { [key: string]: Reducer } = {},
+) {
+  const sagas: any = typeof saga === 'function' ? { saga } : saga;
+  const prepared = prepareStore({
+    reducers,
+    sagas,
+  });
+  const store: any = createStore(
+    prepared.reducer,
+    applyMiddleware(...prepared.middleware),
+  );
+  prepared.run();
+  return store;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,11 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux-batched-actions@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/redux-batched-actions/-/redux-batched-actions-0.5.0.tgz#d3f0e359b2a95c7d80bab442df450bfafd57d122"
+  integrity sha512-6orZWyCnIQXMGY4DUGM0oj0L7oYnwTACsfsru/J7r94RM3P9eS7SORGpr3LCeRCMoIMQcpfKZ7X4NdyFHBS8Eg==
+
 redux-saga-creator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/redux-saga-creator/-/redux-saga-creator-2.0.1.tgz#7433cea4c5ec2d06159c307de7008ba490bc0061"
@@ -1861,10 +1866,10 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-robodux@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/robodux/-/robodux-11.0.1.tgz#7b4284031b049908bf1c28522afd04229701b898"
-  integrity sha512-qxMQoz2cufZC8o58MwDGBQVlg2WouzvTxlS1Ahwe+wsgV8D9vPDldRISj+UF3v0eK8cMDREiSU7osdumw0Jyzw==
+robodux@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/robodux/-/robodux-11.0.2.tgz#91b4407a8881be102641f65a6038537adb963c16"
+  integrity sha512-bZYTlCCCz8CHeczBg13vqiz7pjnINp5PdoUMORLlndxXZzS6xVatrzLat+v0amFWp0eERs1k1yCg9lkQjRLZRQ==
   dependencies:
     immer "^8.0.1"
 


### PR DESCRIPTION
`prepareStore` will setup `redux-batched-actions`, `redux-saga`, and some built-in reducers to make dev easier.

This PR will bring a massive change to how people interact with `saga-query`.  The idea is to streamline some of the code by sacrificing some of the decisions end-users can make.

In particular, we are going to nudge people towards using `prepareStore` which will make a bunch of assumptions about how people are going to use `saga-query`.  The end result will be a more opinionated way to use this library.

This PR also revamps the middleware that was created to use the assumptions in `prepareStore`.