### PR TITLE
performance monitor middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ state.**
 - [Polling](#polling)
 - [Optimistic UI](#optimistic-ui)
 - [Undo](#undo)
-- [Performance Tracking](#performance-tracking)
+- [Performance monitor](#performance-monitor)
 - [redux-toolkit](#redux-toolkit)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ state.**
 - [Polling](#polling)
 - [Optimistic UI](#optimistic-ui)
 - [Undo](#undo)
+- [Performance Tracking](#performance-tracking)
 - [redux-toolkit](#redux-toolkit)
 
 ## Features
@@ -936,6 +937,30 @@ function* undoer<Ctx extends UndoCtx = UndoCtx>() {
   if (winner.undo) return;
   yield next();
 }
+```
+
+# Performance monitor
+
+```ts
+import { delay } from 'redux-saga/effects';
+import { performanceMonitor, createPipe, wrap, PerfCtx } from 'saga-query';
+
+const thunks = createPipe<PerfCtx>();
+thunks.use(performanceMonitor);
+thunks.use(function* (ctx, next) {
+  yield next();
+  console.log(`calling ${ctx.name} took ${ctx.performance} ms`);
+});
+thunks.use(thunks.routes());
+
+function* slowSaga() {
+  yield delay(10 * 1000);
+}
+
+const slow = thunks.create('something-slow', wrap(slowSaga));
+
+store.dispatch(slow());
+// calling something-slow took 10000 ms
 ```
 
 ## A note on `robodux`

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "react-redux": "^7.2.5",
-    "redux-saga": "^1.1.3"
+    "react-redux": "^7.2.5"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -70,6 +69,7 @@
   },
   "dependencies": {
     "redux-batched-actions": "^0.5.0",
+    "redux-saga": "^1.1.3",
     "redux-saga-creator": "^2.0.1",
     "robodux": "^13.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export { BATCH, batchActions } from 'redux-batched-actions';
+export * from 'redux-saga/effects';
+
 export * from './pipe';
 export * from './api';
 export * from './types';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -261,3 +261,31 @@ export function requestMonitor<Ctx extends ApiCtx = ApiCtx>(
 export function requestParser<Ctx extends ApiCtx = ApiCtx>() {
   return compose<Ctx>([urlParser, simpleCache]);
 }
+
+export interface PerfCtx<P = any> extends PipeCtx<P> {
+  performance: number;
+}
+
+export function* performanceMonitor<Ctx extends PerfCtx = PerfCtx>(
+  ctx: Ctx,
+  next: Next,
+) {
+  if (!performance) {
+    yield next();
+    return;
+  }
+
+  const t0 = performance.now();
+  yield next();
+  const t1 = performance.now();
+  ctx.performance = t1 - t0;
+}
+
+export function wrap<Ctx extends PipeCtx = PipeCtx>(
+  saga: (...args: any[]) => any,
+) {
+  return function* (ctx: Ctx, next: Next) {
+    yield call(saga, ctx.action);
+    yield next();
+  };
+}

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -57,11 +57,6 @@ const users = createTable<User>({ name: 'USER' });
 const tickets = createTable<Ticket>({ name: 'TICKET' });
 const reducers = createReducerMap(users, tickets);
 
-interface FetchApiOpts {
-  url: RequestInfo;
-  options?: RequestInit;
-}
-
 const mockUser = { id: '1', name: 'test', email_address: 'test@test.com' };
 const mockTicket = { id: '2', name: 'test-ticket' };
 
@@ -242,7 +237,7 @@ test('error handling - error handler', (t) => {
     onError: (err: Error) => t.assert(err.message === 'failure'),
   });
   api.use(api.routes());
-  api.use(function* upstream(ctx, next) {
+  api.use(function* upstream() {
     throw new Error('failure');
   });
 


### PR DESCRIPTION
Based on the request from this [redux-saga discussion](https://github.com/redux-saga/redux-saga/discussions/2253) I thought it might be a good idea to make it a little easier to use `saga-query` for performance monitoring.