### PR TITLE
Key identity on v4.0.0

### DIFF
--- a/src/create-key.test.ts
+++ b/src/create-key.test.ts
@@ -318,7 +318,7 @@ test('options object keys order for action key identity - 5: other', (t) => {
   t.assert(getKeyOf(falsy0) !== getKeyOf(falsy2));
   t.assert(getKeyOf(falsy1) !== getKeyOf(falsy2));
   t.assert(getKeyOf(falsy1) !== getKeyOf(falsy3));
-  t.assert(getKeyOf(falsy3) === getKeyOf(falsy4));
+  t.assert(getKeyOf(falsy3) !== getKeyOf(falsy4));
   t.assert(getKeyOf(primNo0) !== getKeyOf(falsy0));
   t.assert(getKeyOf(primNo0) !== getKeyOf(primNo1));
   t.assert(getKeyOf(primNo1) !== getKeyOf(primNo2));

--- a/src/create-key.test.ts
+++ b/src/create-key.test.ts
@@ -1,0 +1,334 @@
+import test from 'ava';
+import type { ActionWithPayload } from './types';
+import { createApi } from './api';
+import { poll } from './middleware';
+
+const getKeyOf = (action: ActionWithPayload<any>): string => action.payload.key;
+
+test('options object keys order for action key identity - 0: empty options', (t) => {
+  t.plan(1);
+  const api = createApi();
+  api.use(api.routes());
+  // no param
+  const action0 = api.get(
+    '/users',
+    { saga: poll(5 * 1000) }, // with poll middleware
+    function* (ctx, next) {
+      ctx.request = {
+        method: 'GET',
+      };
+      yield next();
+    },
+  );
+  const sendNop0 = action0();
+  const sendNop1 = action0();
+  t.assert(getKeyOf(sendNop0) === getKeyOf(sendNop1));
+});
+
+test('options object keys order for action key identity - 1: simple object', (t) => {
+  t.plan(4);
+  const api = createApi();
+  api.use(api.routes());
+  // no param
+  const action0 = api.get<any>(
+    '/users',
+    { saga: poll(5 * 1000) }, // with poll middleware
+    function* (ctx, next) {
+      ctx.request = {
+        method: 'GET',
+      };
+      yield next();
+    },
+  );
+  const sendPojo0 = action0({
+    a: 'a',
+    b: 'b',
+    c: 1,
+    d: 2,
+    e: true,
+    f: false,
+    '100': 100,
+    101: '101',
+  });
+  const sendPojo1 = action0({
+    a: 'a',
+    b: 'b',
+    c: 1,
+    d: 2,
+    e: true,
+    f: false,
+    100: 100,
+    101: '101',
+  });
+  const sendPojo2 = action0({
+    e: true,
+    f: false,
+    '100': 100,
+    '101': '101',
+    a: 'a',
+    b: 'b',
+    c: 1,
+    d: 2,
+  });
+  const sendPojo3 = action0({
+    e: true,
+    f: false,
+    '100': 100,
+    '101': '101',
+    a: 'a',
+    b: 'b',
+    c: 1,
+    d: 2000000,
+  });
+  const sendPojo4 = action0({
+    e: null,
+    f: false,
+    '100': undefined,
+    '101': '101',
+    a: 'a',
+    b: 'b',
+    c: 1,
+    d: `Thomas O'Malley`,
+  });
+  const sendPojo5 = action0({
+    d: `Thomas O'Malley`,
+    e: null,
+    f: false,
+    '100': undefined,
+    '101': '101',
+    a: 'a',
+    b: 'b',
+    c: 1,
+  });
+  t.assert(getKeyOf(sendPojo0) === getKeyOf(sendPojo1));
+  t.assert(getKeyOf(sendPojo0) === getKeyOf(sendPojo2));
+  t.assert(getKeyOf(sendPojo0) !== getKeyOf(sendPojo3));
+  t.assert(getKeyOf(sendPojo4) === getKeyOf(sendPojo5));
+});
+
+test('options object keys order for action key identity - 2: object (with array values)', (t) => {
+  interface Ip0 {
+    param1: string;
+    param2: string[];
+  }
+  t.plan(2);
+  const api = createApi();
+  api.use(api.routes());
+  const action = api.get<Ip0>('/users/:param1/:param2', function* (ctx, next) {
+    ctx.request = {
+      method: 'GET',
+    };
+    yield next();
+  });
+  const sendFirst = action({ param1: '1', param2: ['2', 'e', 'f'] });
+  const sendSecond = action({ param2: ['2', 'f', 'e'], param1: '1' });
+  const sendThird = action({ param2: ['2', 'e', 'f'], param1: '1' });
+  t.assert(getKeyOf(sendFirst) !== getKeyOf(sendSecond)); // array is different
+  t.assert(getKeyOf(sendFirst) === getKeyOf(sendThird)); // object has same keys same values
+});
+
+test('options object keys order for action key identity - 3: nested object', (t) => {
+  interface Ip0 {
+    param1: string;
+    param2: string[];
+  }
+  interface Ip1 {
+    param1: string;
+    param2: string;
+    param3: number;
+    param4: Ip0;
+    param5: boolean;
+  }
+  const o1: Ip1 = {
+    param1: '1',
+    param2: '2',
+    param3: 3,
+    param4: {
+      param1: '4',
+      param2: ['5', '6'],
+    },
+    param5: true,
+  };
+  const o2: Ip1 = {
+    param4: {
+      param1: '4',
+      param2: ['5', '6'],
+    },
+    param5: true,
+    param2: '2',
+    param1: '1',
+    param3: 3,
+  };
+  t.plan(2);
+  const api = createApi();
+  api.use(api.routes());
+  //nested with array
+  const action2 = api.get<Ip1>(
+    '/users/:param1/:param2/:param3/:param4/:param5',
+    function* (ctx, next) {
+      ctx.request = {
+        method: 'GET',
+      };
+      yield next();
+    },
+  );
+  const sendO1 = action2(o1);
+  const sendO2 = action2(o2);
+  const sendO3 = action2({
+    ...o1,
+    param4: { ...o1.param4, param2: ['5', '6', '7'] },
+  });
+  t.assert(getKeyOf(sendO1) === getKeyOf(sendO2));
+  t.assert(getKeyOf(sendO1) !== getKeyOf(sendO3));
+});
+
+test('options object keys order for action key identity - 4: deepNested object', (t) => {
+  interface Ip0 {
+    param1: string;
+    param2: string[];
+  }
+  interface Ip1 {
+    param1: string;
+    param2: string;
+    param3: number;
+    param4: Ip0;
+    param5: boolean;
+  }
+  interface Ip3 {
+    param1: string;
+    param2: {
+      param3: Ip1;
+      param4: Ip0;
+    };
+  }
+  const o1: Ip1 = {
+    param1: '1',
+    param2: '2',
+    param3: 3,
+    param4: {
+      param1: '4',
+      param2: ['5', '6'],
+    },
+    param5: true,
+  };
+  const o2: Ip1 = {
+    param4: {
+      param1: '4',
+      param2: ['5', '6'],
+    },
+    param5: true,
+    param1: '1',
+    param2: '2',
+    param3: 3,
+  };
+  const oo1: Ip3 = {
+    param1: '1',
+    param2: {
+      param3: o1,
+      param4: {
+        param1: '4',
+        param2: ['5', '6'],
+      },
+    },
+  };
+  const oo2: Ip3 = {
+    param1: '1',
+    param2: {
+      param4: {
+        param1: '4',
+        param2: ['5', '6'],
+      },
+      param3: o1,
+    },
+  };
+  t.plan(4);
+  const api = createApi();
+  api.use(api.routes());
+  // deepNested
+  const action4 = api.get<Ip3>(
+    '/users/:param1/:param2/:param3/:param4/:param5',
+    function* (ctx, next) {
+      ctx.request = {
+        method: 'GET',
+      };
+      yield next();
+    },
+  );
+  const send_oo1 = action4(oo1);
+  const send_oo1_shuff = action4({ param2: oo1.param2, param1: oo1.param1 });
+  const send_oo1_value_changed = action4({ ...oo1, param1: 'x' });
+  const send_oo2 = action4(oo2);
+  t.deepEqual(send_oo1.payload.options, send_oo2.payload.options);
+  t.assert(getKeyOf(send_oo1) === getKeyOf(send_oo1_shuff));
+  t.assert(getKeyOf(send_oo1) !== getKeyOf(send_oo1_value_changed));
+  t.assert(getKeyOf(send_oo1) === getKeyOf(send_oo2)); // deep nested shuffled //
+});
+
+test('options object keys order for action key identity - 5: other', (t) => {
+  t.plan(17);
+  const api = createApi();
+  api.use(api.routes());
+  //array options
+  const action5 = api.post<any>('/users/:allRecords', function* (ctx, next) {
+    ctx.request = {
+      method: 'POST',
+      body: JSON.stringify(ctx.action.payload),
+    };
+    yield next();
+  });
+  const falsy0 = action5(0);
+  const falsy1 = action5(false);
+  const falsy2 = action5('');
+  const falsy3 = action5(undefined);
+  const falsy4 = action5(null);
+  const primNo0 = action5(NaN);
+  const primNo1 = action5(1);
+  const primNo1bis = action5(1);
+  const primNo2 = action5(2);
+  const str1 = action5('1234');
+  const str1bis = action5('1234');
+  const str2 = action5('2345');
+  const aStrings1 = action5(['1', '2', '3']);
+  const aStrings2 = action5(['1', '2', '3']);
+  const aStrings3 = action5(['1', '2', '1']);
+  const aObjects1 = action5([
+    { param1: '1', param2: ['2', '3'] },
+    { param1: '2', param2: ['2', '3'] },
+  ]);
+  const aObjects2 = action5([
+    { param1: '1', param2: ['2', '3'] },
+    { param1: '2', param2: ['2', '3'] },
+  ]);
+  // the objects are not identical.
+  const aObjects3 = action5([
+    { param1: '1', param2: ['2', '3'] },
+    { param1: '2', param2: ['2', 3] },
+  ]);
+  //object inside the array is shuffled
+  const aObjects4 = action5([
+    { param2: ['2', '3'], param1: '1' },
+    { param2: ['2', '3'], param1: '2' },
+  ]);
+  // cont the order of array elements is changed will get different keys.
+  const aObjects5 = action5([
+    { param1: '2', param2: ['2', '3'] },
+    { param1: '1', param2: ['2', '3'] },
+  ]);
+  t.assert(getKeyOf(falsy0) !== getKeyOf(falsy1));
+  t.assert(getKeyOf(falsy0) !== getKeyOf(falsy2));
+  t.assert(getKeyOf(falsy1) !== getKeyOf(falsy2));
+  t.assert(getKeyOf(falsy1) !== getKeyOf(falsy3));
+  t.assert(getKeyOf(falsy3) === getKeyOf(falsy4));
+  t.assert(getKeyOf(primNo0) !== getKeyOf(falsy0));
+  t.assert(getKeyOf(primNo0) !== getKeyOf(primNo1));
+  t.assert(getKeyOf(primNo1) !== getKeyOf(primNo2));
+  t.assert(getKeyOf(primNo1) === getKeyOf(primNo1bis));
+  t.assert(getKeyOf(str1) !== getKeyOf(str2));
+  t.assert(getKeyOf(str1) === getKeyOf(str1bis));
+  t.assert(getKeyOf(aStrings1) === getKeyOf(aStrings2));
+  t.assert(getKeyOf(aStrings1) !== getKeyOf(aStrings3));
+  t.assert(getKeyOf(aObjects1) === getKeyOf(aObjects2));
+  t.assert(getKeyOf(aObjects1) !== getKeyOf(aObjects3));
+  t.assert(getKeyOf(aObjects1) === getKeyOf(aObjects4));
+  t.assert(getKeyOf(aObjects1) !== getKeyOf(aObjects5));
+});

--- a/src/create-key.ts
+++ b/src/create-key.ts
@@ -1,15 +1,25 @@
 import { isObject } from './util';
+import { encodeBase64 } from './encoding';
 
-export const koSort = (opts?: any): object => {
-  if (opts === null || opts === undefined) return {};
-  if (!isObject(opts)) return { opts: opts };
+const deepSortObject = (opts?: any): any => {
+  if (!isObject(opts)) return opts;
   return Object.keys(opts)
     .sort()
     .reduce((res: any, key: any) => {
       res[`${key}`] = opts[key];
       if (opts[key] && isObject(opts[key])) {
-        res[`${key}`] = koSort(opts[key]);
+        res[`${key}`] = deepSortObject(opts[key]);
       }
       return res;
     }, {});
+};
+
+export const createActionKey = (name: string, options?: any) => {
+  const enc =
+    typeof options !== undefined
+      ? encodeBase64(JSON.stringify(deepSortObject(options)))
+      : '';
+  const encKey = enc ? `|${enc}` : '';
+  const key = `${name}${encKey}`;
+  return key;
 };

--- a/src/create-key.ts
+++ b/src/create-key.ts
@@ -1,0 +1,15 @@
+import { isObject } from './util';
+
+export const koSort = (opts?: any): object => {
+  if (opts === null || opts === undefined) return {};
+  if (!isObject(opts)) return { opts: opts };
+  return Object.keys(opts)
+    .sort()
+    .reduce((res: any, key: any) => {
+      res[`${key}`] = opts[key];
+      if (opts[key] && isObject(opts[key])) {
+        res[`${key}`] = koSort(opts[key]);
+      }
+      return res;
+    }, {});
+};

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -8,7 +8,7 @@ import { requestMonitor } from './middleware';
 const baseUrl = 'https://saga-query.com';
 const mockUser = { id: '1', email: 'test@saga-query.com' };
 
-const delay = (n: number = 50) =>
+const delay = (n: number = 200) =>
   new Promise((resolve) => {
     setTimeout(resolve, n);
   });

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -2,7 +2,8 @@ import { call, takeEvery } from 'redux-saga/effects';
 import type { SagaIterator } from 'redux-saga';
 import sagaCreator from 'redux-saga-creator';
 
-import { createActionKey, isFn, isObject } from './util';
+import { isFn, isObject } from './util';
+import { createActionKey } from './create-key';
 import type {
   Middleware,
   MiddlewareCo,

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,8 +4,6 @@ import { prepareStore } from './store';
 
 import { API_ACTION_PREFIX } from './constants';
 import { ApiRequest, RequiredApiRequest } from '.';
-import { encodeBase64 } from './encoding';
-import { koSort } from './create-key';
 
 export const isFn = (fn?: any) => fn && typeof fn === 'function';
 export const isObject = (obj?: any) => typeof obj === 'object' && obj !== null;
@@ -58,14 +56,4 @@ export const mergeRequest = (
     ...next,
     headers: mergeHeaders((cur as any).headers, (next as any).headers),
   };
-};
-
-export const createActionKey = (name: string, options?: any) => {
-  const enc =
-    typeof options !== undefined
-      ? encodeBase64(JSON.stringify(koSort(options)))
-      : '';
-  const encKey = enc ? `|${enc}` : '';
-  const key = `${name}${encKey}`;
-  return key;
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,8 @@ import { prepareStore } from './store';
 import { API_ACTION_PREFIX } from './constants';
 import { ApiRequest, RequiredApiRequest } from '.';
 import { encodeBase64 } from './encoding';
+import { koSort } from './create-key';
+
 export const isFn = (fn?: any) => fn && typeof fn === 'function';
 export const isObject = (obj?: any) => typeof obj === 'object' && obj !== null;
 export const createAction = (curType: string) => {
@@ -59,7 +61,10 @@ export const mergeRequest = (
 };
 
 export const createActionKey = (name: string, options?: any) => {
-  const enc = options ? encodeBase64(JSON.stringify(options)) : '';
+  const enc =
+    typeof options !== undefined
+      ? encodeBase64(JSON.stringify(koSort(options)))
+      : '';
   const encKey = enc ? `|${enc}` : '';
   const key = `${name}${encKey}`;
   return key;


### PR DESCRIPTION
Created a function to sort the keys of option object to ensure the identity of the "key" property of actions payload, on same endpoint with same parameters.
We have to be able to recreate the key when necessary based on the properties of the action.
The proposed function orders recursively the keys of an object. In case of primitive values it just settles to an object to get stringified later on.
In case of an array it doesn't sort the elements of the array but it sorts the keys within the elements of the array if they are objects.
The sort function will not alter the way the options are set. It prepares the object to be stringified along with the name of the action but will not interfere with the option object as it was passed.

Having concerns about the unlikely situation when two different falsy primitives are provided I came up with minor change  in utils.ts too.
```js
const enc =  (typeof options !== undefined)  ? encodeBase64(JSON.stringify(koSort(options)))  : '';
```
If this is not desired for any reason I will happily change the test file.